### PR TITLE
typo in init.d results in flawed installation when building a ....

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -25,7 +25,7 @@
 ### END INIT INFO
 
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON=/usr/sbin/mysql-smnp
+DAEMON=/usr/sbin/mysql-snmp
 DAEMON2="/usr/bin/perl"
 NAME=mysql-snmp
 DESC="Mysql SNMP Agent"


### PR DESCRIPTION
...deb package and installing using dpkg).  In particular, /etc/init.d/mysql-snmp quietly dies without an error message.

-Mike
