### PR TITLE
update debian control file to require snmpd (>= 5.4.3) explicitly

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: mysql-snmp
 Architecture: all
-Depends: ${perl:Depends}, snmpd, libsnmp-perl, libunix-syslog-perl, ${shlibs:Depends}, ${misc:Depends}
+Depends: ${perl:Depends}, snmpd (>= 5.4.3), libsnmp-perl, libunix-syslog-perl, ${shlibs:Depends}, ${misc:Depends}
 Description: SNMP agent for mysql-server
  This package contains a SNMP agent/subagent to expose Mysql-server
  internal counters to SNMP.


### PR DESCRIPTION
To prevent careless people like myself from making the mistake described in Issue #14.
