### PR TITLE
Actually exit after printing version message

### DIFF
--- a/mysql-snmp
+++ b/mysql-snmp
@@ -1104,7 +1104,7 @@ sub run
         'man',
         'usage',
         'verbose|v+',
-        'version|V' => sub {VersionMessage()},
+        'version|V' => sub {VersionMessage(); exit 0;},
     ) or pod2usage(-verbose => 0);
 
     pod2usage(-verbose => 0) if $opt{usage};


### PR DESCRIPTION
Current code silently runs as a daemon in background when -V or --version command-line option is specified. Expected behaviour is for the program to terminate after displaying the version message. 

Signed-off-by: Masood Behabadi masood@dentcat.com
